### PR TITLE
Revisiones

### DIFF
--- a/src/helpers/getSmallPokemons.ts
+++ b/src/helpers/getSmallPokemons.ts
@@ -3,6 +3,10 @@ import { type SmallPokemon } from "~/interfaces/small-pokemon";
 
 export const getSmallPokemons = async (offset: number = 0, limit: number = 10): Promise<SmallPokemon[]> => {
 
+  if ( offset < 0 ) offset = 0;
+  if ( limit < 0 ) limit = 10;
+
+
   let response: SmallPokemon[] = [];
   try {
     console.log(`🔹 fetch to: https://pokeapi.co/api/v2/pokemon?limit=${limit}&offset=${offset}`);

--- a/src/routes/pokemons/list-ssr/index.tsx
+++ b/src/routes/pokemons/list-ssr/index.tsx
@@ -4,17 +4,14 @@ import { getSmallPokemons } from '~/helpers/getSmallPokemons';
 import { type SmallPokemon } from '~/interfaces/small-pokemon';
 
 
-export const usePokemonList = routeLoader$<SmallPokemon[]>(async ({ query }) => {
-  console.log('🔸 query: ', query);
+export const usePokemonList = routeLoader$<SmallPokemon[]>(async ({ query, redirect }) => {
 
-  const offset = query.get('offset');
-  console.log(' 🟨 offset: ', offset);
-
-  if (offset) {
-    typeof offset;
-    console.log('🟨 typeof offset: ', typeof offset);
+  const offset = query.get('offset') ? +query.get('offset')! : 0;
+  if( offset < 0 )  {
+    throw redirect(302, `/pokemons/list-ssr?offset=0`);
   }
-  return await getSmallPokemons(+(offset ?? 0));
+
+  return await getSmallPokemons( offset );
 })
 
 export default component$(() => {
@@ -23,12 +20,8 @@ export default component$(() => {
   const location = useLocation();
 
   const currenOffset = useComputed$<number>(() => {
-    // const res = location.url.searchParams.get('offset');
 
-    const offset = new URLSearchParams(location.url.search);
-    console.log('currenOffset -> offset: ', offset);
-
-    console.log(+( offset.get('offset') ?? '0'));
+    const offset = new URLSearchParams(location.url.search);    
     return +( offset.get('offset') ?? '0');
   })
 
@@ -41,10 +34,10 @@ export default component$(() => {
       </div>
       
       <div class="mt-10">
-        <Link class="btn btn-primary mr-2" href={`/pokemons/list-ssr?offset=${ (currenOffset.value - 10) }`}>
+        <Link class="btn btn-primary mr-2" reload prefetch href={`/pokemons/list-ssr?offset=${ (currenOffset.value - 10) }`}>
           ANTERIORES
         </Link>
-        <Link class="btn btn-primary mr-2" href={`/pokemons/list-ssr?offset=${ (currenOffset.value + 10) }`}>
+        <Link class="btn btn-primary mr-2" reload prefetch  href={`/pokemons/list-ssr?offset=${ (currenOffset.value + 10) }`}>
           SIGUIENTES
         </Link>
       </div>


### PR DESCRIPTION
Parece que cambiaron un poco el comportamiento del redirect y el routerLoader en Qwik para que el cliente tome el control del routeLoader.

Por eso no me saca ni lanza el error si ya cargó la ruta. Pero eso permite poder hacer el prefetch.

Revisa los cambios que hice, básicamente lo que tendríamos que hacer si queremos evitar que el URL refleje valores negativos, es validar cual es el valor que podemos asignar con otras propiedades computadas o una función

También revisa esto, es relacionado al problema
https://github.com/BuilderIO/qwik/issues/2409